### PR TITLE
Package fixup

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "description": "mirz <mirz.hq@gmail.com>",
   "main": "build/aalib.js",
-  "author": "",
+  "author": "mirz <that.mirz@gmail.com>",
   "license": "MIT",
+  "repository": "https://github.com/mir3z/aali",
   "scripts": {
     "dev": "webpack-dev-server --hot --inline --progress --colors --config dev/webpack.config.js",
     "build": "webpack --progress --colors",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "aalib.js",
   "version": "0.1.0",
   "description": "mirz <mirz.hq@gmail.com>",
+  "main": "build/aalib.js",
   "author": "",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Adding `main` key to `project.json`. This allows others to use this library like so


```
{"dependencies": {"aalib.js": "mir3z/aalib.js"}}
```

And then just `node -e "require('aalib.js')"`

Also adding `author` and `repository` fields, the latter avoids a warning when installing aalib.js.